### PR TITLE
Move staticfiles calls to static

### DIFF
--- a/bigday/templates/base.html
+++ b/bigday/templates/base.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/bigday/templates/home.html
+++ b/bigday/templates/home.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load staticfiles %}
+{% load static %}
 {% block page_head %}
     <!-- Custom CSS -->
     <link href="{% static 'bigday/css/creative.css' %}" rel="stylesheet">

--- a/bigday/templates/partials/gifts.html
+++ b/bigday/templates/partials/gifts.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
 <div class="container">
         <h2 class="section-heading text-center">Gifts</h2>
         <hr class="primary">

--- a/bigday/templates/partials/save-the-dates.html
+++ b/bigday/templates/partials/save-the-dates.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
 <section id="save-the-dates" class="bg-info">
     <div class="container">
         <div class="row">

--- a/bigday/templates/partials/wedding-party.html
+++ b/bigday/templates/partials/wedding-party.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
 <section id="wedding-party">
     <div class="container">
         <div class="row">

--- a/guests/templates/guests/email_templates/email_base.html
+++ b/guests/templates/guests/email_templates/email_base.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
 <html>
 <head>
     <meta http-equiv="content-type" content="text/html; charset=utf-8">

--- a/guests/templates/guests/email_templates/invitation.html
+++ b/guests/templates/guests/email_templates/invitation.html
@@ -1,5 +1,5 @@
 {% extends 'guests/email_templates/email_base.html' %}
-{% load staticfiles %}
+{% load static %}
 {% block header_image %}{% endblock %}
 {% block lead_copy %}
     <tr>

--- a/guests/templates/guests/email_templates/save_the_date.html
+++ b/guests/templates/guests/email_templates/save_the_date.html
@@ -1,5 +1,5 @@
 {% extends 'guests/email_templates/email_base.html' %}
-{% load staticfiles %}
+{% load static %}
 {% block main_image %}
     <a href="{{ site_url }}"
        {% if email_mode %}target="_blank"{% endif %}>

--- a/guests/templates/guests/invitation.html
+++ b/guests/templates/guests/invitation.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load staticfiles %}
+{% load static %}
 {% block page_head %}
     <link href="{% static 'bigday/css/invitation.css' %}" rel="stylesheet" xmlns="http://www.w3.org/1999/html">
 {% endblock %}

--- a/guests/templates/guests/rsvp_confirmation.html
+++ b/guests/templates/guests/rsvp_confirmation.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load staticfiles %}
+{% load static %}
 {% block page_head %}
     <link href="{% static 'bigday/css/rsvp-confirmation.css' %}" rel="stylesheet" xmlns="http://www.w3.org/1999/html">
 {% endblock %}


### PR DESCRIPTION
The `staticfiles` requirement was dropped in Django 1.10 - https://docs.djangoproject.com/en/1.10/ref/templates/builtins/#static

Support was fully dropped in Django 3.0, making the calls error and the site fail to run