### PR TITLE
Change psycopg2 dependency to binary

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 django>=2.2.2
 Fabric==1.10.2
-psycopg2==2.7.4
+psycopg2-binary==2.9.3


### PR DESCRIPTION
The other pip package requires build dependencies on the host, whereas psycopg2-binary is a binary package that doesn't require any build tools.