### PR TITLE
Pin Django dependency to < 4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-django>=2.2.2
+django>=2.2.2,<4.0
 Fabric==1.10.2
 psycopg2==2.7.4


### PR DESCRIPTION
Django 4.0 doesn't seem to be compatible with this codebase, as running the migrate command throws this ImportError:

  File /home/mike/django-wedding-website/bigday/urls.py, line 1, in <module>
    from django.conf.urls import url, include
ImportError: cannot import name 'url' from 'django.conf.urls' (/home/mike/.local/lib/python3.8/site-packages/django/conf/urls/__init__.py)