### PR TITLE
Bump Django to 4.1.2, adding security fixes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-django==4.1
+django==4.1.2
 Fabric==1.10.2
 psycopg2-binary==2.9.3


### PR DESCRIPTION
Bumped Django because of [CVE-2022-41323](https://www.djangoproject.com/weblog/2022/oct/04/security-releases/).

Most likely, internationalizations are not used here, but I did not run into compatibility errors. So it should be safe to merge.