### PR TITLE
BUGFIX: Add 'couple_name' to invite context

### DIFF
--- a/guests/views.py
+++ b/guests/views.py
@@ -115,6 +115,7 @@ def rsvp_confirm(request, invite_id=None):
     return render(request, template_name='guests/rsvp_confirmation.html', context={
         'party': party,
         'support_email': settings.DEFAULT_WEDDING_REPLY_EMAIL,
+        'couple_name' : settings.BRIDE_AND_GROOM,
     })
 
 

--- a/guests/views.py
+++ b/guests/views.py
@@ -85,6 +85,7 @@ def invitation(request, invite_id):
     return render(request, template_name='guests/invitation.html', context={
         'party': party,
         'meals': MEALS,
+        'couple_name' : settings.BRIDE_AND_GROOM,
     })
 
 


### PR DESCRIPTION
This variable was missing from invite context, so the invite page would render the title as "'s big day" instead of f"{couple_name}'s big day"