### PR TITLE
Add unique_addresses_only option for send_invitation_email

### DIFF
--- a/guests/invitation.py
+++ b/guests/invitation.py
@@ -36,12 +36,15 @@ def get_invitation_context(party):
     }
 
 
-def send_invitation_email(party, test_only=False, recipients=None):
+def send_invitation_email(party, test_only=False, recipients=None, unique_addresses_only=False):
     if recipients is None:
         recipients = party.guest_emails
     if not recipients:
         print ('===== WARNING: no valid email addresses found for {} ====='.format(party))
         return
+    if unique_addresses_only:
+        # Remove duplicate emails within this party party
+        recipients = list(dict.fromkeys(recipients))
 
     context = get_invitation_context(party)
     context['email_mode'] = True


### PR DESCRIPTION
This option removes any duplicate email addresses in 'recipients' for the party before sending email (useful if guests within a party share an email address)