### PR TITLE
Bumped Django to LTS release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-django==4.1.13
+django==4.2.8
 Fabric==1.10.2
 psycopg2-binary==2.9.3


### PR DESCRIPTION
According to [the Django download page](https://www.djangoproject.com/download/) the 4.1.X version is no longer maintained and will not get any security fixes.

Thus I bumped the version to the current LTS release (4.2.8), which works fine in my production environment.

Maybe we should pin the release as `4.*` to avoid PRs every month?